### PR TITLE
ダメージ計算の小数点以下の処理を修正

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function effectiveDamage(power, armor, armorPenetration) {
   let effectiveArmor = normalize(armor) - normalize(armorPenetration);
   effectiveArmor = effectiveArmor <= 0 ? 0 : effectiveArmor;
   const damageDecrease = effectiveArmor / (100 + effectiveArmor);
-  return Math.floor(normalize(power) * (1 - damageDecrease));
+  return Math.round(normalize(power) * (1 - damageDecrease));
 }
 
 /**


### PR DESCRIPTION
仕様では四捨五入となっていたが、実装が切り捨て(floor)になっていたので、
仕様通りの処理(round)に修正した。