### PR TITLE
ダメージ計算の結果を小数点以下切り捨てにしていたところを、小数点以下四捨五入するように修正した

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ function effectiveDamage(power, armor, armorPenetration) {
   let effectiveArmor = normalize(armor) - normalize(armorPenetration);
   effectiveArmor = effectiveArmor <= 0 ? 0 : effectiveArmor;
   const damageDecrease = effectiveArmor / (100 + effectiveArmor);
-  return Math.floor(normalize(power) * (1 - damageDecrease));
+  return Math.round(normalize(power) * (1 - damageDecrease));
 }
 
 /**


### PR DESCRIPTION
ダメージ計算の仕様では、ダメージ量の小数点以下を四捨五入して整数にする、と記載があるが切り捨てていた。
ダメージ量の小数点以下を四捨五入するように修正した。